### PR TITLE
adding collectd to the monitoring

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,7 +31,7 @@ default.influxdb.base_dir                   = node.hopsmonitor.dir + "/influxdb"
 default.influxdb.conf_dir                   = node.influxdb.base_dir + "/conf"
 default.influxdb.pid_file                   = "/tmp/influxdb.pid"
 default.influxdb.graphite.port              = "2003"
-
+default.influxdb.series.max                 = 0
 
 default.grafana.version                     = "4.1.1-1484211277"
 default.grafana.url                         = "#{node.download_url}/grafana-#{node.grafana.version}.linux-x64.tar.gz"

--- a/recipes/_influxdb.rb
+++ b/recipes/_influxdb.rb
@@ -187,7 +187,7 @@ for dbname in node.influxdb.databases do
 
   # Create a test retention policy on the test database
   execute 'add_retention_policy_to_graphite' do
-    command "#{exec_pwd} \"CREATE RETENTION POLICY one_week ON #{dbname} DURATION 1w REPLICATION 1\""
+    command "#{exec_pwd} \"CREATE RETENTION POLICY one_week ON #{dbname} DURATION 1w REPLICATION 1 DEFAULT\""
     not_if "#{exec_pwd} 'show retention policies on grep #{dbname}' | grep one_week"
   end
 

--- a/templates/default/influxdb.conf.erb
+++ b/templates/default/influxdb.conf.erb
@@ -58,7 +58,7 @@ auth-enabled = true
   dir = "<%= node.influxdb.base_dir %>/data"
   # The directory where the TSM storage engine stores WAL files.                                                                                                                                                                                                                                                
   wal-dir = "<%= node.influxdb.base_dir %>/wal"
-
+  max-series-per-database = "<%= node.influxdb.series.max %>"
 ###	   
 ### [[graphite]]
 ###                 


### PR DESCRIPTION
Set one week retention policy as default for graphite, otherwise it is not used by data coming from spark.

Set the max-series-per-database to 0 to have an unlimited number of series per database.